### PR TITLE
use only interfaces that have been around for a long time

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -79,8 +79,7 @@ function removeRoot(rootPEM) {
   let removedAnyCerts = false;
   while (enumerator.hasMoreElements()) {
     let cert = enumerator.getNext().QueryInterface(Ci.nsIX509Cert);
-    if (cert.sha256SubjectPublicKeyInfoDigest ==
-        tempCert.sha256SubjectPublicKeyInfoDigest) {
+    if (cert.sha1Fingerprint == tempCert.sha1Fingerprint) {
       // This is for versions before bug 643041 merged these interfaces.
       if ("nsIX509Cert2" in Ci) {
         cert.QueryInterface(Ci.nsIX509Cert2);


### PR DESCRIPTION
nsIX509Cert.sha256SubjectPublicKeyInfoDigest was added in 31. nsIX509Cert.sha1Fingerprint has been around for a long time. Unfortunately this means that instead of removing all certs with the bad key, we're only removing exactly the certs we specify (or someone has found a sha-1 collision, which is still improbable).
